### PR TITLE
avoid null pointer errors on blob drawing

### DIFF
--- a/examples/processing/ngageApi/Blob.pde
+++ b/examples/processing/ngageApi/Blob.pde
@@ -51,7 +51,8 @@ class Blob {
     beginShape();
     for (int i=0; i < contours.size(); i++){
       PVector pt = contours.get(i);
-      vertex(pt.x, pt.y);
+      if (pt != null)
+        vertex(pt.x, pt.y);
     }
     endShape();
   }

--- a/examples/processing/ngageApi/ngageApi.pde
+++ b/examples/processing/ngageApi/ngageApi.pde
@@ -56,7 +56,8 @@ void drawBlob(Blob b) {
   beginShape();
   for (int j = 0; j< b.contours.size(); j++) {
     PVector pt = (PVector) b.contours.get(j);
-    vertex(pt.x*width, pt.y*height);
+    if (pt != null)
+      vertex(pt.x*width, pt.y*height);
   }
   endShape();
 


### PR DESCRIPTION
Blob drawing can sometimes NPE due to null points, possibly the result of threading problems.
